### PR TITLE
Add Docker deploy workflow with environment overrides

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Target environment'
+        required: true
+        default: 'staging'
+        type: choice
+        options:
+          - staging
+          - prod
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_NAME: ghcr.io/MichaelCrowe11/crowecad
+      ENVIRONMENT: ${{ github.event.inputs.environment || 'staging' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build, migrate and restart
+        run: |
+          export IMAGE_TAG=${GITHUB_SHA}
+          docker-compose -f docker-compose.yml -f docker-compose.${ENVIRONMENT}.yml pull
+          docker-compose -f docker-compose.yml -f docker-compose.${ENVIRONMENT}.yml up -d --build
+          docker tag crowecad ${IMAGE_NAME}:${IMAGE_TAG}
+          docker push ${IMAGE_NAME}:${IMAGE_TAG}
+          docker-compose -f docker-compose.yml -f docker-compose.${ENVIRONMENT}.yml exec -T crowecad npm run db:migrate
+          docker-compose -f docker-compose.yml -f docker-compose.${ENVIRONMENT}.yml restart crowecad

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.env
+.env.*

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,4 @@
+services:
+  crowecad:
+    environment:
+      NODE_ENV: production

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -1,0 +1,4 @@
+services:
+  crowecad:
+    environment:
+      NODE_ENV: staging

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3.9'
+services:
+  crowecad:
+    build: .
+    image: ghcr.io/MichaelCrowe11/crowecad:${IMAGE_TAG:-latest}
+    ports:
+      - "5000:5000"
+    depends_on:
+      - postgres
+  postgres:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_USER: crowecad
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: crowecad
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+volumes:
+  postgres_data:


### PR DESCRIPTION
## Summary
- add Docker-based deploy workflow that builds, migrates and restarts via docker-compose
- tag images with git SHA and support staging/prod overrides
- include base docker-compose files and .gitignore

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_689fc22190848327a1df116fe780e25f