### PR TITLE
chore: validate required env vars with dotenv-safe

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Database
+DATABASE_URL=
+PGUSER=
+PGPASSWORD=
+PGDATABASE=
+
+# OpenAI
+OPENAI_API_KEY=
+OPENAI_ASSISTANT_ID=
+
+# Anthropic
+ANTHROPIC_API_KEY=
+
+# GitHub (for skill mining)
+GITHUB_TOKEN=

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
         "compromise": "^14.14.4",
         "connect-pg-simple": "^10.0.0",
         "date-fns": "^3.6.0",
+        "dotenv-safe": "^8.2.0",
         "drizzle-orm": "^0.39.1",
         "drizzle-zod": "^0.7.0",
         "dxf-parser": "^1.1.2",
@@ -7507,6 +7508,24 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-safe": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv-safe/-/dotenv-safe-8.2.0.tgz",
+      "integrity": "sha512-uWwWWdUQkSs5a3mySDB22UtNwyEYi0JtEQu+vDzIqr9OjbDdC2Ip13PnSpi/fctqlYmzkxCeabiyCAOROuAIaA==",
+      "license": "MIT",
+      "dependencies": {
+        "dotenv": "^8.2.0"
+      }
+    },
+    "node_modules/dotenv-safe/node_modules/dotenv": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
+      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/drizzle-kit": {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "compromise": "^14.14.4",
     "connect-pg-simple": "^10.0.0",
     "date-fns": "^3.6.0",
+    "dotenv-safe": "^8.2.0",
     "drizzle-orm": "^0.39.1",
     "drizzle-zod": "^0.7.0",
     "dxf-parser": "^1.1.2",

--- a/server/db.ts
+++ b/server/db.ts
@@ -2,14 +2,9 @@ import { Pool, neonConfig } from '@neondatabase/serverless';
 import { drizzle } from 'drizzle-orm/neon-serverless';
 import ws from "ws";
 import * as schema from "@shared/schema";
+import { DATABASE_URL } from "./env";
 
 neonConfig.webSocketConstructor = ws;
 
-if (!process.env.DATABASE_URL) {
-  throw new Error(
-    "DATABASE_URL must be set. Did you forget to provision a database?",
-  );
-}
-
-export const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+export const pool = new Pool({ connectionString: DATABASE_URL });
 export const db = drizzle({ client: pool, schema });

--- a/server/env.ts
+++ b/server/env.ts
@@ -1,0 +1,21 @@
+import { config } from 'dotenv-safe';
+
+config();
+
+const requireEnv = (name: string): string => {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} must be set`);
+  }
+  return value;
+};
+
+export const DATABASE_URL = requireEnv('DATABASE_URL');
+export const OPENAI_API_KEY = requireEnv('OPENAI_API_KEY');
+export const ANTHROPIC_API_KEY = requireEnv('ANTHROPIC_API_KEY');
+
+export const OPENAI_ASSISTANT_ID = process.env.OPENAI_ASSISTANT_ID || '';
+export const PGUSER = process.env.PGUSER || '';
+export const PGPASSWORD = process.env.PGPASSWORD || '';
+export const PGDATABASE = process.env.PGDATABASE || '';
+export const GITHUB_TOKEN = process.env.GITHUB_TOKEN || '';

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,6 +1,7 @@
 import express, { type Request, Response, NextFunction } from "express";
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
+import "./env";
 
 const app = express();
 app.use(express.json());

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -11,6 +11,7 @@ import {
   insertCommandSchema
 } from "@shared/schema";
 import { z } from "zod";
+import { OPENAI_API_KEY } from './env';
 
 export async function registerRoutes(app: Express): Promise<Server> {
   // Initialize equipment types on startup
@@ -426,7 +427,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   // OpenAI-powered CAD operations
   // Dynamically import and use OpenAI routes if API key is available
-  if (process.env.OPENAI_API_KEY) {
+  if (OPENAI_API_KEY) {
     const openaiRouter = (await import('./routes/openai')).default;
     app.use('/api/openai', openaiRouter);
     app.use('/api/crowecad', openaiRouter); // Also available under /api/crowecad

--- a/server/routes/openai.ts
+++ b/server/routes/openai.ts
@@ -5,6 +5,7 @@ import { skillMiner } from '../../client/src/lib/skill-miner';
 import multer from 'multer';
 import fs from 'fs/promises';
 import path from 'path';
+import { OPENAI_API_KEY, OPENAI_ASSISTANT_ID } from '../env';
 
 // Configure multer for file uploads
 const upload = multer({
@@ -25,7 +26,7 @@ const router = Router();
 
 // Initialize OpenAI client
 const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY || '',
+  apiKey: OPENAI_API_KEY,
 });
 
 // Schema for CAD generation request
@@ -159,7 +160,7 @@ ${relevantSkills.slice(0, 3).map(s =>
     const run = await openai.beta.threads.runs.create(
       threadId,
       {
-        assistant_id: process.env.OPENAI_ASSISTANT_ID || 'asst_crowecad',
+        assistant_id: OPENAI_ASSISTANT_ID,
         instructions: buildDynamicInstructions(relevantSkills)
       }
     );
@@ -620,12 +621,12 @@ function extractCodeBlocks(text: string): Array<{ type: string; code: string }> 
 
 // Health check
 router.get('/health', (req, res) => {
-  const hasApiKey = !!process.env.OPENAI_API_KEY;
+  const hasApiKey = !!OPENAI_API_KEY;
   res.json({
     status: hasApiKey ? 'healthy' : 'missing_api_key',
     features: {
       generation: hasApiKey,
-      assistant: hasApiKey && !!process.env.OPENAI_ASSISTANT_ID,
+      assistant: hasApiKey && !!OPENAI_ASSISTANT_ID,
       codeInterpreter: hasApiKey,
       imageAnalysis: hasApiKey,
       query: hasApiKey,

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -11,6 +11,11 @@ process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/crowecad_test'
 process.env.NODE_ENV = 'test';
 process.env.OPENAI_API_KEY = 'test-api-key';
 process.env.ANTHROPIC_API_KEY = 'test-api-key';
+process.env.OPENAI_ASSISTANT_ID = 'asst_test';
+process.env.PGUSER = 'test';
+process.env.PGPASSWORD = 'test';
+process.env.PGDATABASE = 'crowecad_test';
+process.env.GITHUB_TOKEN = 'test-token';
 
 // Mock window.matchMedia
 Object.defineProperty(window, 'matchMedia', {


### PR DESCRIPTION
## Summary
- enforce OpenAI and Anthropic API key checks via centralized env loader
- gate database connection on validated env vars
- provide .env.example for docker deployment variables

## Testing
- `npx vitest run` *(fails: Playwright suite misconfiguration and unresolved imports)*

------
https://chatgpt.com/codex/tasks/task_b_689fc1ec7b8083278a413d2a63df0da4