### PR TITLE
Add drizzle migrations and equipment seed scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run db:migrate
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      - run: npm test --if-present

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ db-migrate: ## Run database migrations
 
 .PHONY: db-seed
 db-seed: ## Seed database
-	docker exec -i crowecad-db psql -U crowecad -d crowecad < init.sql
+	npm run db:seed
 
 .PHONY: db-reset
 db-reset: docker-down ## Reset database

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "drizzle-kit";
+
+export default defineConfig({
+  schema: "./shared/schema.ts",
+  out: "./drizzle",
+  dialect: "postgresql",
+  dbCredentials: {
+    url: process.env.DATABASE_URL!,
+  },
+});

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:migrate": "drizzle-kit push",
+    "db:seed": "tsx server/seed.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.37.0",


### PR DESCRIPTION
## Summary
- configure drizzle-kit for PostgreSQL and expose db:migrate/db:seed scripts
- make equipment type seeding idempotent and runnable as a standalone script
- add CI workflow to run migrations in GitHub Actions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: TypeScript errors in server/routes/openai.ts)*
- `npm run db:migrate` *(fails: DATABASE_URL not set)*

------
https://chatgpt.com/codex/tasks/task_b_689fc242d4288327b561788fa17938b9